### PR TITLE
The `e` tag was missing in the documentation.

### DIFF
--- a/Inuktitut-Java/Uqailaut/README.txt
+++ b/Inuktitut-Java/Uqailaut/README.txt
@@ -161,6 +161,7 @@ v : verb root
 n : noun root
 a : adverb
 c : conjunction
+e : exclamation
 q : tail suffix
 nn : noun-to-noun suffix
 nv : noun-to-verb suffix


### PR DESCRIPTION
 Changes to be committed:
	modified:   README.txt